### PR TITLE
docs(prerequisites): supported python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Follow these steps to set up and run Ecoute on your local machine.
 
 ### 📋 Prerequisites
 
-- Python 3.x
+- Python >=3.8.0
 - An OpenAI API key
 - Windows OS (Not tested on others)
 - FFmpeg 


### PR DESCRIPTION
In another PR I am preparing, I am adding poetry to manage dependencies. Since no version is specified in the `requirements.txt` it defaults to `torch = "^2.0.1"`.

Depending on our recommended version of `torch`, the earliest version of python supported is Python 3.6 (according to ChatGPT).

```
The current project's Python requirement (>=3.0,<4.0) is not compatible with some of the required packages Python requirement:
  - torch requires Python >=3.8.0, so it will not be satisfied for Python >=3.0,<3.8.0
```

I recommend updating this line to 3.8, but if you'd like to support 3.6, I think that is an acceptable version, depending on the requirements.